### PR TITLE
Aboyd105205 word conversion

### DIFF
--- a/Theory/Packet/GTP packet.svg
+++ b/Theory/Packet/GTP packet.svg
@@ -136,7 +136,7 @@
      <g class="com.sun.star.drawing.TextShape">
       <g id="id11">
        <rect class="BoundingBox" stroke="none" fill="none" x="3540" y="14462" width="14479" height="4065"/>
-       <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="1270px" font-weight="400"><tspan class="TextPosition" x="5591" y="15738"><tspan fill="rgb(0,0,0)" stroke="none">Body ( 0-255 bits )</tspan></tspan></tspan></text>
+       <text class="TextShape"><tspan class="TextParagraph" font-family="Liberation Sans, sans-serif" font-size="1270px" font-weight="400"><tspan class="TextPosition" x="5591" y="15738"><tspan fill="rgb(0,0,0)" stroke="none">Body ( 0-255 words )</tspan></tspan></tspan></text>
       </g>
      </g>
      <g class="com.sun.star.drawing.TextShape">

--- a/Theory/Packet/Packet.txt
+++ b/Theory/Packet/Packet.txt
@@ -26,4 +26,4 @@ PACKET
                 Each group of 12 bytes represents one 3-vector, with each section of 4 being an integer
 	
 	Content
-		Data( 0-255 bits )
+		Data( 0-255 words )

--- a/Theory/Packet/Packet.txt
+++ b/Theory/Packet/Packet.txt
@@ -9,6 +9,7 @@ PACKET
         Destination( 8 bits )
         Size ( 8 bits )
         Datatype( 8 bits )
+	Total Size: 1 word
 
     BODY
         Purpose


### PR DESCRIPTION
There is no point in specifying the body in size of bits because we are transmitting in terms of words, I think we should use size to specify how many words are in a packet.